### PR TITLE
Fix: Remove $ shown on APY/APR displays

### DIFF
--- a/src/pages/Compound.tsx
+++ b/src/pages/Compound.tsx
@@ -57,7 +57,7 @@ export default function Compound() {
     return (
       compoundAPY ? (
         <Pill className="mt-8 m-auto text-xl min-w-[100%]">
-          ~${compoundAPY}% APY 
+          ~{compoundAPY}% APY
         </Pill>
       ) : null
     )

--- a/src/pages/Marinate.tsx
+++ b/src/pages/Marinate.tsx
@@ -40,7 +40,7 @@ export default function Marinate() {
   const aprPill = React.useMemo(() => {
     return marinateAPR ? (
       <Pill className="mt-8 m-auto text-xl min-w-full">
-        ~${marinateAPR}% APR
+        ~{marinateAPR}% APR
       </Pill>
     ) : null
   }, [marinateAPR])


### PR DESCRIPTION
## Explanation of change
This PR removes an extra `$` character that was found on the Compound and Marinate pages for the APY & APR displays.


## UI Changes 
Marinate: Top; Compound: Bottom;
### BEFORE
![marinate-before cleaned](https://user-images.githubusercontent.com/107085338/177023651-cbbffafd-52d3-4e53-ad86-9010ec20f9a4.jpg)
![compound-before cleaned](https://user-images.githubusercontent.com/107085338/177023649-2fa97750-3e5d-4890-b6d5-b24ada2d7483.jpg)

### AFTER
![marinate-after cleaned](https://user-images.githubusercontent.com/107085338/177023660-681da6cb-9540-49a7-a272-4ee299d7e63d.jpg)
![compound-after cleaned](https://user-images.githubusercontent.com/107085338/177023658-33682e38-1f33-483c-9ac7-72727a05de9a.jpg)